### PR TITLE
Fix for missing MutationObserver on window object - #8

### DIFF
--- a/properties.js
+++ b/properties.js
@@ -32,6 +32,7 @@ module.exports = [
   'FocusEvent',
   'PopStateEvent',
   'UIEvent',
+  'MutationObserver',
   'MouseEvent',
   'KeyboardEvent',
   'TouchEvent',


### PR DESCRIPTION
Possible fix, not sure how to actually test this in Atom.